### PR TITLE
Auto-generated PR: issue 594

### DIFF
--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -65,6 +65,44 @@ server {
 
 Mutual TLS (mTLS) is a security method that uses client certificates to verify both the server and the client during communication. This ensures that both NGINX Instance Manager and NGINX Plus instances are securely authenticated, protecting your network from unauthorized access.
 
+---
+
+## Certificate Revocation Checking (CRL/OCSP)
+
+{{< important >}}
+**Omitting certificate revocation checking can create a false sense of security.** Even with `ssl_verify` enabled, revoked certificates (due to compromise, mis-issuance, or other reasons) may still be accepted if revocation checking is not configured. This can allow unauthorized or malicious access.
+{{< /important >}}
+
+**Best Practice:** When configuring SSL/TLS for NGINX Instance Manager, always enable certificate revocation checking to ensure that revoked certificates are not accepted.
+
+NGINX supports two main methods for certificate revocation checking:
+
+- **Certificate Revocation Lists (CRL):** Use the [`ssl_crl`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_crl) directive to specify a file with a list of revoked certificates.
+- **Online Certificate Status Protocol (OCSP):** Use the [`ssl_ocsp`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ocsp) directive to enable OCSP validation of client certificates.
+
+For detailed implementation steps, see:
+- [NGINX SSL Termination Guide: OCSP Validation of Client Certificates](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#ocsp-validation-of-client-certificates)
+- [NGINX `ssl_crl` directive](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_crl)
+- [NGINX `ssl_ocsp` directive](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ocsp)
+
+**Example: Enabling CRL and OCSP in a server block**
+
+```nginx
+server {
+    listen 443 ssl;
+    ...
+    ssl_client_certificate /etc/nms/certs/ca.pem;
+    ssl_verify_client on;
+    ssl_crl /etc/nms/certs/ca.crl;  # Path to your CRL file
+    ssl_ocsp on;                    # Enable OCSP checking
+    ...
+}
+```
+
+> **Note:** Ensure your CA provides up-to-date CRLs or supports OCSP for effective revocation checking.
+
+---
+
 With mTLS, each NGINX instance has a unique client certificate that NGINX Instance Manager verifies before allowing communication. You can configure NGINX as a proxy to handle client certificates for this secure exchange.
 
 Follow these steps to set up mTLS using a Public Key Infrastructure (PKI) system:


### PR DESCRIPTION
Attempt to resolve issue 594

The user has requested that the documentation for configuring SSL/TLS for NGINX Instance Manager explicitly mention the importance of certificate revocation checking (using CRLs or OCSP) as a best practice. They want a note or section added to inform users about the risks of not checking for revoked certificates and, ideally, provide guidance or references on how to implement revocation checking.

Reviewing the potential documents, the most relevant is `content/nim/system-configuration/secure-traffic.md`, which is the main guide for securing traffic between NGINX Instance Manager and NGINX instances. This document currently covers SSL/TLS setup, mTLS, and the use of `ssl_verify`, but does not mention certificate revocation checking (CRL or OCSP) as a best practice, nor does it provide guidance on how to implement it.

Other documents, such as `content/nginx/admin-guide/security-controls/terminating-ssl-http.md`, do provide technical details on enabling OCSP and CRL in NGINX, but are more general and not specific to NGINX Instance Manager. The main actionable change should be in the NIM secure traffic guide, with references to the more detailed NGINX documentation for implementation steps.

No changes are needed to the certificate management guides (`content/nim/nginx-instances/manage-certificates.md`), as these focus on certificate storage and rotation, not on runtime validation or revocation checking.

Therefore, the plan is to update `content/nim/system-configuration/secure-traffic.md` to:
- Add a note or section (e.g., under "Mutual Client Certificate Authentication Setup (mTLS)" or as a new "Best Practices" section) explaining the importance of certificate revocation checking.
- Briefly describe the risks of not checking for revoked certificates.
- Provide actionable guidance or references on how to enable CRL and OCSP checking in NGINX, linking to the relevant NGINX documentation (such as the "OCSP Validation of Client Certificates" section in `terminating-ssl-http.md`).
- Optionally, add a short example or reference for using the `ssl_crl` and `ssl_ocsp` directives.

This will address the user request and improve the security guidance for users configuring SSL/TLS for NGINX Instance Manager.