### PR TITLE
Auto-generated PR: issue 594

### DIFF
--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -465,6 +465,29 @@ To generate the necessary certificates, follow these steps. You can modify these
 
 ---
 
+## Certificate Revocation Checking (CRL/OCSP)
+
+{{< call-out "note" "Best Practice: Check for Revoked Certificates" >}}
+Enabling certificate revocation checking is a recommended best practice when configuring SSL/TLS for NGINX Instance Manager. Without revocation checking, revoked certificates—such as those that are compromised or mis-issued—may still be accepted, reducing the security of your deployment.
+
+NGINX supports certificate revocation checking using either Certificate Revocation Lists (CRLs) or the Online Certificate Status Protocol (OCSP):
+
+- **OCSP**: To enable OCSP validation, add the following directive to your server block:
+
+    ```nginx
+    ssl_ocsp on;
+    ```
+    
+    For more information and advanced configuration, see the [NGINX SSL Termination guide's OCSP section](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#setup_ocsp).
+
+- **CRL**: To enable CRL checking, use the [`ssl_crl`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_crl) directive:
+
+    ```nginx
+    ssl_crl /path/to/ca-crl.pem;
+    ```
+
+{{< /call-out >}}
+
 ## Configure SSL verification for usage reporting with self-signed certificates {#configure-ssl-verify}
 
 {{<call-out "note" "Version requirements" "">}}


### PR DESCRIPTION
Attempt to resolve issue 594

The user has raised a valid concern that the current NGINX Instance Manager documentation, specifically the "Secure client access and network traffic" guide, does not mention or recommend certificate revocation checking (using CRLs or OCSP) as a best practice. This omission could lead users to configure SSL/TLS in a way that does not check for revoked certificates, potentially accepting compromised or invalid certificates and creating a false sense of security.

Reviewing the potential documents, the most relevant is `content/nim/system-configuration/secure-traffic.md`, which is the main guide for securing traffic between NGINX Instance Manager and NGINX instances. This document covers SSL/TLS setup, mTLS, and the use of `ssl_verify`, but does not mention certificate revocation checking (CRL or OCSP) or provide guidance on enabling it.

The NGINX SSL Termination guide (`content/nginx/admin-guide/security-controls/terminating-ssl-http.md`) does include a section on OCSP validation of client certificates, but this is not referenced or linked from the Instance Manager documentation, and the Instance Manager guide does not explain the importance of revocation checking or how to enable it in the context of NGINX Instance Manager.

The other documents (certificate management, usage tracking, etc.) are not directly relevant to the configuration of SSL/TLS verification and revocation checking between NGINX Plus/Agent and Instance Manager.

Therefore, the main change should be to update `content/nim/system-configuration/secure-traffic.md` to:
- Explicitly mention certificate revocation checking (CRL and OCSP) as a best practice.
- Add a note or section explaining the risks of not checking for revoked certificates.
- Provide at least a brief explanation or link to the NGINX SSL Termination guide's OCSP section, and/or example configuration for enabling OCSP or CRL checking in NGINX.
- Optionally, add a cross-reference in the NGINX SSL Termination guide to highlight its relevance for Instance Manager users, but the primary change is in the Instance Manager documentation.