### PR TITLE
Auto-generated PR: issue 228

### DIFF
--- a/content/nginx-one/about.md
+++ b/content/nginx-one/about.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-The F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
+F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
 
 ## Benefits and key features
 

--- a/content/nginx-one/glossary.md
+++ b/content/nginx-one/glossary.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-This glossary defines terms used in the F5 NGINX One Console and F5 Distributed Cloud.
+This glossary defines terms used in F5 NGINX One Console and F5 Distributed Cloud.
 
 
 {{<bootstrap-table "table table-striped table-bordered">}}

--- a/content/nginx-one/metrics/review-metrics.md
+++ b/content/nginx-one/metrics/review-metrics.md
@@ -12,7 +12,7 @@ nd-content-type: how-to
 nd-product: NGINX-One
 ---
 
-After connecting your NGINX instances to NGINX One, you can monitor their performance and health. The NGINX One dashboard is designed for this purpose, offering an easy-to-use interface.
+After connecting your NGINX instances to NGINX One, you can monitor their performance and health. NGINX One dashboard is designed for this purpose, offering an easy-to-use interface.
 
 ### Log in to NGINX One
 

--- a/content/solutions/nginx-one-subscription.md
+++ b/content/solutions/nginx-one-subscription.md
@@ -33,14 +33,14 @@ Monitor and manage your NGINX data planes through the NGINX One service in F5 Di
 
 ## Access to NGINX One
 
-After your NGINX One subscription is activated, the contact provided to F5 will receive an email invitation to MyF5 and your tenant in F5 Distributed Cloud. Within [F5 Distributed Cloud](https://console.ves.volterra.io/), you can access the NGINX One Cloud Console and explore other F5 Distributed Cloud services. In [MyF5](https://my.f5.com/), you’ll find all the licensing and fulfillment objects needed to access and deploy NGINX One software components.
+After your NGINX One subscription is activated, the contact provided to F5 will receive an email invitation to MyF5 and your tenant in F5 Distributed Cloud. Within [F5 Distributed Cloud](https://console.ves.volterra.io/), you can access the NGINX One console and explore other F5 Distributed Cloud services. In [MyF5](https://my.f5.com/), you’ll find all the licensing and fulfillment objects needed to access and deploy NGINX One software components.
 
 ## NGINX One in F5 Distributed Cloud
 
 Manage configurations, monitor your infrastructure, address security vulnerabilities, and assess the health of your NGINX fleet—all from a single console in F5 Distributed Cloud.
 
-- [Learn more about NGINX One Cloud Console](https://docs.nginx.com/nginx-one/about/)
-- [Get started with NGINX One Cloud Console](https://docs.nginx.com/nginx-one/getting-started/)
+- [Learn more about NGINX One console](https://docs.nginx.com/nginx-one/about/)
+- [Get started with NGINX One console](https://docs.nginx.com/nginx-one/getting-started/)
 - [Log in to F5 Distributed Cloud](https://console.ves.volterra.io/)
 
 ## F5 NGINX Plus


### PR DESCRIPTION
Attempt to resolve issue 228

The user's intent is to ensure that all documentation consistently follows the style guide rules regarding product names: specifically, not using articles ("the", "a", "an") before product names and using the correct capitalization (e.g., "NGINX One Console" instead of "NGINX One console"). The issue content provides clear examples and references the style guide, which explicitly states these requirements.

To address this, we need to identify and update all documentation files where product names are used incorrectly—either with articles preceding them or with incorrect capitalization. The potential documents list includes several files that mention NGINX products, especially "NGINX One Console," "NGINX Agent," and related terms.

A review of the provided document contents reveals several places where:
- Articles may be used before product names (e.g., "the NGINX One Console," "the NGINX Agent").
- Product names may not be capitalized correctly (e.g., "NGINX One console" instead of "NGINX One Console").
- There may be inconsistent usage across landing pages, feature descriptions, and glossaries.

The style guide itself does not need to be updated, as it already contains the correct guidance. The main focus should be on the product documentation files, especially those that serve as landing pages, overviews, glossaries, and feature guides.

The plan should be to:
1. Review each document for incorrect article usage and capitalization of product names.
2. Update all instances to remove articles before product names and ensure correct capitalization.
3. Pay special attention to summary/landing pages, glossaries, and any document that introduces or describes NGINX products.