### PR TITLE
Auto-generated PR: issue 594

### DIFF
--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -475,6 +475,10 @@ Starting with NGINX Plus R33, NGINX Plus must report usage data to a reporting e
 
 The [`ssl_verify`](https://nginx.org/en/docs/ngx_mgmt_module.html#ssl_verify) directive in the [`mgmt`](https://nginx.org/en/docs/ngx_mgmt_module.html) block ensures that NGINX Plus connects only to trusted reporting endpoints by validating the server's SSL certificate. The `ssl_verify` directive is set to `on` by default.
 
+{{< important >}}
+Enabling 'ssl_verify' ensures that certificates are valid and trusted, but does not check if a certificate has been revoked. For enhanced security, we recommend enabling certificate revocation checking (using OCSP or CRLs) to prevent the acceptance of revoked certificates. See the [NGINX SSL Termination guide](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#setup_ocsp) for instructions on enabling OCSP validation in your NGINX configuration.
+{{< /important >}}
+
 ### Why `ssl_verify` is important
 
 When `ssl_verify` is enabled:


### PR DESCRIPTION
Attempt to resolve issue 594

The user has raised a valid security concern: the current documentation for securing SSL/TLS traffic between NGINX Instance Manager and NGINX instances (specifically, the guide at `content/nim/system-configuration/secure-traffic.md`) does not mention the importance of checking for revoked certificates (via CRLs or OCSP). While the guide covers enabling `ssl_verify`, it omits that this alone does not protect against revoked certificates, which could be accepted if revocation checking is not enabled. This gap has led to negative customer feedback.

The most relevant document to update is `content/nim/system-configuration/secure-traffic.md`, as it is the main guide for securing traffic and already discusses SSL/TLS, `ssl_verify`, and related best practices. The NGINX SSL Termination guide (`content/nginx/admin-guide/security-controls/terminating-ssl-http.md`) already contains a section on OCSP validation, but the Instance Manager guide does not reference or recommend it.

Other documents in the candidate list (such as certificate management, agent mTLS, or usage reporting) are not the primary place for this best-practice warning, though cross-references could be considered in the future.

The plan should be to add a clear note or section in `content/nim/system-configuration/secure-traffic.md` (ideally in the SSL/mTLS setup or `ssl_verify` explanation) that:

- Explains that enabling `ssl_verify` only checks certificate validity and trust, not revocation status.
- Recommends enabling certificate revocation checking (via OCSP or CRLs) as a best practice for production security.
- Optionally, links to the NGINX SSL Termination guide for instructions on enabling OCSP/CRL checking.

This will address the customer concern, improve the documentation's completeness, and help users avoid a false sense of security.