### PR TITLE
Auto-generated PR: issue 594

### DIFF
--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -475,6 +475,21 @@ Starting with NGINX Plus R33, NGINX Plus must report usage data to a reporting e
 
 The [`ssl_verify`](https://nginx.org/en/docs/ngx_mgmt_module.html#ssl_verify) directive in the [`mgmt`](https://nginx.org/en/docs/ngx_mgmt_module.html) block ensures that NGINX Plus connects only to trusted reporting endpoints by validating the server's SSL certificate. The `ssl_verify` directive is set to `on` by default.
 
+{{< important >}}
+**Certificate revocation checking is a recommended best practice.**
+
+Enabling `ssl_verify` ensures that certificates are valid and trusted, but it does not check if a certificate has been revoked (for example, due to compromise or mis-issuance). Without revocation checking, revoked certificates may still be accepted, which can compromise the security of your deployment.
+
+To enhance security, configure NGINX to check for certificate revocation using OCSP (Online Certificate Status Protocol) or Certificate Revocation Lists (CRLs). For details and configuration examples, see the [OCSP Validation of Client Certificates](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ocsp) section in the NGINX documentation, or refer to the [NGINX SSL Termination guide](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#ocsp-validation-of-client-certificates).
+
+Example (enabling OCSP validation in an NGINX server block):
+
+```nginx
+ssl_ocsp on;
+```
+
+{{< /important >}}
+
 ### Why `ssl_verify` is important
 
 When `ssl_verify` is enabled:


### PR DESCRIPTION
Attempt to resolve issue 594

The user has raised a valid security concern: the current "Secure client access and network traffic" documentation for NGINX Instance Manager describes how to configure SSL/TLS and enable certificate verification (`ssl_verify on;`), but it does not mention certificate revocation checking (using CRLs or OCSP). This omission could lead users to believe their setup is fully secure, when in fact revoked certificates could still be accepted, exposing them to risk.

The issue content specifically requests that the documentation be updated to mention the importance of certificate revocation checking as a best practice, and to provide either instructions or at least a clear note that users should implement revocation checking (via CRLs or OCSP) to avoid accepting compromised or invalid certificates.

Reviewing the potential documents, the most relevant is:
- `content/nim/system-configuration/secure-traffic.md` ("Secure client access and network traffic")

This document is the main guide for securing traffic between NGINX Instance Manager and NGINX instances, and is where users would expect to find best practices and security recommendations for SSL/TLS configuration. The other documents are about certificate management, general SSL/TLS setup, or are not directly related to the configuration of SSL/TLS verification and revocation checking for NGINX Instance Manager.

The NGINX SSL Termination guide (`content/nginx/admin-guide/security-controls/terminating-ssl-http.md`) does mention OCSP validation for client certificates, but the main guide for NGINX Instance Manager does not reference this or provide guidance on revocation checking.

Therefore, the change should be made to `content/nim/system-configuration/secure-traffic.md`, adding a clear note or section that:
- Explains the risk of not checking for revoked certificates.
- Recommends enabling certificate revocation checking (via CRLs or OCSP) as a best practice.
- Optionally, provides a brief example or link to the relevant NGINX documentation for enabling OCSP or CRL checking.

No changes are needed to the other documents, as they are not the primary location for this guidance.