### PR TITLE
Auto-generated PR: issue 113

### DIFF
--- a/content/includes/nim/admin-guide/auth/basic-auth-api-requests.md
+++ b/content/includes/nim/admin-guide/auth/basic-auth-api-requests.md
@@ -2,6 +2,10 @@
 docs: DOCS-1295
 ---
 
+{{< call-out "info" "Authentication method" >}}
+These instructions apply when NGINX Instance Manager is using basic authentication (the default after installation). If your deployment is configured to use OpenID Connect (OIDC), you must use a Bearer token for API authentication instead. For details, see the [OIDC authentication guide]({{< ref "/nim/admin-guide/authentication/oidc/getting-started.md" >}}).
+{{< /call-out >}}
+
 To use basic authentication for API requests, include your base64-encoded credentials as a "Basic" token in the "Authorization" header. To create the base64-encoded credentials, run the following command:
 
 ```bash

--- a/content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md
+++ b/content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md
@@ -1,5 +1,21 @@
 ---
 title: Set up basic authentication
+
+## Authentication Methods Overview
+
+NGINX Instance Manager supports two authentication methods: **Basic Authentication** (default) and **OpenID Connect (OIDC)**. 
+
+- **Basic Authentication** is enabled by default after installation. All users, including the default `admin`, authenticate with a username and password. 
+- **OIDC** must be explicitly configured. When OIDC is enabled, **basic authentication is disabled for all users**, including the default `admin` account. OIDC allows authentication via an external identity provider and supports bearer token authentication for API requests.
+
+| Authentication Method | Default After Install | API Example Format | When to Use | Reference |
+|----------------------|----------------------|-------------------|-------------|-----------|
+| Basic Auth           | Yes                  | `-u user:pass` or `Authorization: Basic ...` | For most new installations and unless OIDC is configured | [This guide](#) |
+| OIDC (Bearer Token)  | No                   | `Authorization: Bearer <token>` | When OIDC is explicitly configured and enabled | [OIDC Guide](../oidc/getting-started.md) |
+
+{{< call-out "note" "API Example Note" >}}
+Some API examples in the NGINX Instance Manager documentation use bearer tokens (OIDC). These only work if OIDC is enabled. For default/basic setups, use basic authentication as shown in this guide.{{< /call-out >}}
+
 description: Learn how to manage user access in NGINX Instance Manager using basic authentication with NGINX as a front-end proxy. This guide covers first-time login, creating additional users, and setting passwords.
 toc: true
 weight: 10

--- a/content/nim/admin-guide/authentication/oidc/getting-started.md
+++ b/content/nim/admin-guide/authentication/oidc/getting-started.md
@@ -8,6 +8,23 @@ type:
 - tutorial
 ---
 
+{{<call-out "note" "Authentication methods in NGINX Instance Manager">}}
+NGINX Instance Manager uses **basic authentication** by default. You must explicitly configure and enable OpenID Connect (OIDC) if you want to use it. When OIDC is enabled, basic authentication is disabled for all users, including the default `admin` user. 
+
+**Summary of authentication methods:**
+
+| Scenario | Authentication Method | API Example |
+|----------|----------------------|-------------|
+| Default/"vanilla" deployment | Basic authentication | `curl -u "<USERNAME>:<PASSWORD>" ...` or use `Authorization: Basic <base64_credentials>` |
+| OIDC enabled | Bearer token (OIDC) | `curl --header "Authorization: Bearer <access token>" ...` |
+
+- For details on basic authentication, see [Set up basic authentication](/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication/).
+- For details on OIDC, continue with this guide.
+
+> **Note:**
+> API calls require a bearer token **only** when OIDC is active. If you have not enabled OIDC, use basic authentication for both the web UI and API requests.
+{{</call-out>}}
+
 ## Overview
 
 We recommend using OpenID Connect (OIDC) as the preferred authentication method for NGINX Instance Manager. OIDC offers several advantages, including Single Sign-On (SSO) for users and simplified user management for administrators through user groups. OIDC also enables easy scalability and streamlined user access management.


### PR DESCRIPTION
Attempt to resolve issue 113

The user has identified a documentation gap: there is no clear, centralized explanation of when NGINX Instance Manager (NIM) uses basic authentication versus OIDC bearer tokens, which is the default, and how this affects API usage. This leads to confusion, especially when API examples only show one method (often OIDC bearer tokens), but the default NIM install uses basic authentication. Users following the docs may encounter failed API calls if they use the wrong authentication method.

The issue content specifically requests:
- An introductory explanation at the main authentication documentation page, clarifying when each method is used, which is the default, and under what circumstances each is required.
- API examples (such as those in the WAF config management guide) should show both authentication methods, so users can succeed regardless of their setup.

From the provided potential documents, the following are relevant:
1. `content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md` – covers basic auth, but does not clarify the relationship to OIDC or when each is used.
2. `content/nim/admin-guide/authentication/oidc/getting-started.md` – covers OIDC, but does not clarify the default or the transition from basic auth.
3. `content/nim/nginx-app-protect/setup-waf-config-management.md` (not in the list, but referenced in the issue) – contains API examples that currently only show OIDC bearer token usage.
4. `content/includes/nim/admin-guide/auth/basic-auth-api-requests.md` – provides a basic auth API example, but not in the context of OIDC or as a side-by-side comparison.
5. `content/nms/acm/about/api-overview.md` – describes API auth for ACM, but not the general NIM API.

The main missing piece is a clear, high-level explanation at the top-level authentication documentation, and dual examples in API usage sections.

Therefore, the plan should be:
- Update the main authentication landing page (which is missing in the provided docs, but is likely `content/nim/admin-guide/authentication/_index.md` or similar) to add an overview table or section explaining:
  - Default is basic authentication after install.
  - OIDC is recommended for production and must be explicitly configured.
  - When OIDC is enabled, basic auth is disabled.
  - How to tell which is active, and which API auth method to use.
- Update the basic auth and OIDC guides to cross-reference each other and clarify the default and transition.
- Update API example sections (especially in WAF config management) to show both basic auth and OIDC bearer token examples, with notes on which to use depending on your setup.

Since the main authentication landing page is missing, the best place for the overview is at the top of both the basic auth and OIDC guides, and in any shared includes or API overview docs.