### PR TITLE
Auto-generated PR: issue 463

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
@@ -981,34 +981,59 @@ Prior to compiling NGINX Open Source from source, you need to install libraries 
 
 - [OpenSSL](https://www.openssl.org/) – Supports the HTTPS protocol. Required by the NGINX [SSL](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) module and others.
 
-  ```shell
-  wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./Configure darwin64-x86_64-cc --prefix=/usr
-  make
-  sudo make install
-  ```
+  > **Note:** The OpenSSL build process differs depending on your operating system and CPU architecture. The example command below is specific to Intel-based (x86_64) MacOS systems. For Apple Silicon (ARM64) Macs, Linux, Windows/WSL, or other platforms, see the alternative instructions and consult the [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md) for details on selecting the correct configuration target for your system.
 
-  Example for Ubuntu and Debian:
-  ```shell
-  wget https://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./config --prefix=/usr/local --openssldir=/usr/local/ssl
-  make -j$(nproc)
-  sudo make install
-  ```
+  #### MacOS
+  - **Intel (x86_64):**
+    ```shell
+    wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./Configure darwin64-x86_64-cc --prefix=/usr
+    make
+    sudo make install
+    ```
+  - **Apple Silicon (ARM64):**
+    ```shell
+    wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./Configure darwin64-arm64-cc --prefix=/usr
+    make
+    sudo make install
+    ```
+    To determine your Mac architecture, run:
+    ```shell
+    uname -m
+    ```
+    If the output is `x86_64`, use the Intel instructions above. If it is `arm64`, use the Apple Silicon instructions.
 
-  Example for RHEL-based:
-  ```shell
-  curl -LO https://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./config --prefix=/usr/local --openssldir=/usr/local/ssl
-  make -j$(nproc)
-  sudo make install
-  ```
+  #### Linux
+  On most Linux distributions, use the following:
+    ```shell
+    wget https://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./config --prefix=/usr/local --openssldir=/usr/local/ssl
+    make -j$(nproc)
+    sudo make install
+    ```
+
+  #### RHEL-based Linux
+    ```shell
+    curl -LO https://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./config --prefix=/usr/local --openssldir=/usr/local/ssl
+    make -j$(nproc)
+    sudo make install
+    ```
+
+  #### Windows/WSL
+  For Windows or Windows Subsystem for Linux (WSL), refer to the [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md) for platform-specific instructions and configuration targets.
+
+  > For more information and to identify the correct configuration target for your system, see the official [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md).
+
 
 ### Download the sources {#sources_download}
 


### PR DESCRIPTION
Attempt to resolve issue 463

The issue is about the NGINX documentation for compiling from source, specifically the OpenSSL build instructions. The current documentation provides a build command for OpenSSL that is specific to Intel-based MacOS systems (`./Configure darwin64-x86_64-cc --prefix=/usr`) but does not clarify this, nor does it provide guidance for Apple Silicon (ARM64) Macs, Linux, or Windows/WSL users. It also lacks a link to the official OpenSSL documentation for platform-specific build targets.

The main documentation affected is the NGINX Open Source installation guide, which contains the problematic OpenSSL build instructions. The other potential documents listed (technical specs, container build guides, Unit build guides, etc.) do not contain or discuss the OpenSSL build process for compiling NGINX from source, nor do they provide platform-specific OpenSSL build instructions. Therefore, only the main installation guide for NGINX Open Source needs to be updated.

The required changes are:
- Add a clear note that the provided OpenSSL build command is for Intel-based MacOS.
- Add alternative instructions for Apple Silicon (ARM64) Macs (e.g., `./Configure darwin64-arm64-cc --prefix=/usr`).
- Add guidance for Linux (and possibly Windows/WSL), noting that on Linux, `./config` is typically used, and on Windows, the process is different.
- Add a link to the official OpenSSL INSTALL.md for users to find the correct build target for their system.
- Optionally, split the OpenSSL build instructions into OS-specific sections for clarity.

No other documents require changes, as they do not address the OpenSSL build process for compiling NGINX from source.