### PR TITLE
Auto-generated PR: issue 594

### DIFF
--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -33,6 +33,17 @@ Starting with NGINX Plus R33, you must also enable `ssl_verify` to verify the SS
 
 The example below shows how to set up SSL termination for NGINX Instance Manager:
 
+{{< call-out "note" "Certificate revocation checking (CRL/OCSP) is strongly recommended" >}}
+Checking for revoked certificates is a critical security best practice. Without certificate revocation checking, compromised or invalid certificates may still be accepted, creating a false sense of security and exposing your environment to risk.
+
+NGINX supports certificate revocation checking using both Certificate Revocation Lists (CRL) and the Online Certificate Status Protocol (OCSP):
+
+- **CRL**: Use the [`ssl_crl`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_crl) directive to specify a file with revoked certificates.
+- **OCSP**: Use the [`ssl_ocsp`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ocsp) directive to enable OCSP checking.
+
+We recommend enabling at least one of these methods in your SSL/TLS configuration to ensure that revoked certificates are not accepted. For more details and configuration examples, see the [NGINX SSL Termination guide](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#certificate-revocation-checking).
+{{< /call-out >}}
+
 <details open>
     <summary>/etc/nginx/conf.d/nms-http.conf</summary>
 


### PR DESCRIPTION
Attempt to resolve issue 594

The user has requested that the documentation for configuring SSL/TLS for NGINX Instance Manager explicitly mention the importance of certificate revocation checking (using CRLs or OCSP) as a best practice. They want a note or section added to inform users of the risks of not checking for revoked certificates and, ideally, provide guidance or references on how to implement revocation checking.

Reviewing the potential documents, the most relevant is `content/nim/system-configuration/secure-traffic.md`, which is the main guide for securing traffic between NGINX Instance Manager and NGINX instances. This document currently covers SSL/TLS setup, mTLS, and the use of `ssl_verify`, but does not explicitly mention certificate revocation checking (CRL or OCSP) as a best practice, nor does it provide guidance on how to implement it.

Other documents, such as `content/nginx/admin-guide/security-controls/terminating-ssl-http.md`, do cover OCSP and CRL, but are more general NGINX documentation, not specific to Instance Manager. The user’s request is specifically about the Instance Manager documentation.

Therefore, the change should be made to `content/nim/system-configuration/secure-traffic.md`. The plan should be to add a new note or section (ideally in the SSL/mTLS setup area and/or the "Why ssl_verify is important" section) that:

- Explains the importance of certificate revocation checking (CRL/OCSP) as a best practice.
- Warns of the risks of not checking for revoked certificates (e.g., accepting compromised or invalid certificates).
- Provides brief guidance or references to the main NGINX documentation on how to implement CRL and OCSP checking (e.g., links to `ssl_crl`, `ssl_ocsp`, and related directives in the NGINX docs).

No other documents in the candidate list require updates for this specific issue.