### PR TITLE
Auto-generated PR: issue 113

### DIFF
--- a/content/includes/nim/admin-guide/auth/basic-auth-api-requests.md
+++ b/content/includes/nim/admin-guide/auth/basic-auth-api-requests.md
@@ -2,6 +2,10 @@
 docs: DOCS-1295
 ---
 
+:::note
+This example applies when basic authentication is enabled (the default for new NGINX Instance Manager installations). If OpenID Connect (OIDC) is enabled, you must use a bearer token in the Authorization header instead. For more information, see the [Basic Authentication guide](https://docs.nginx.com/nginx-instance-manager/admin-guide/authentication/basic-auth/set-up-basic-authentication/) and the [OIDC Getting Started guide](https://docs.nginx.com/nginx-instance-manager/admin-guide/authentication/oidc/getting-started/).
+:::
+
 To use basic authentication for API requests, include your base64-encoded credentials as a "Basic" token in the "Authorization" header. To create the base64-encoded credentials, run the following command:
 
 ```bash

--- a/content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md
+++ b/content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md
@@ -15,6 +15,22 @@ h2 {
 }
 </style>
 
+## Authentication Methods Overview
+
+NGINX Instance Manager supports two authentication methods: **Basic Authentication** and **OpenID Connect (OIDC)**.
+
+- **Basic Authentication** is the default after installation. All access to the web UI and API uses a username and password unless OIDC is configured.
+- **OIDC Authentication** (using bearer tokens) is enabled when you configure NGINX Instance Manager to use an external identity provider (IdP). When OIDC is enabled, basic authentication is disabled for all users, and all access (UI and API) requires OIDC authentication.
+
+**How to determine which authentication method is active:**
+- If you see a login page from your organization's identity provider (IdP) when accessing the UI, OIDC is enabled.
+- If you are prompted for a username and password by the browser or API, basic authentication is active.
+
+**Important:**
+- Before using API examples, check which authentication method is configured in your environment. API calls will fail if you use the wrong authentication method (e.g., using a bearer token when basic auth is required, or vice versa).
+- API examples throughout the documentation may use either authentication method. Substitute the correct authentication for your environment.
+- To learn how to enable OIDC, see the [Get started with OIDC guide]({{< ref "/nim/admin-guide/authentication/oidc/getting-started.md" >}}).
+
 ## Overview
 
 NGINX Instance Manager uses NGINX as a front-end proxy and for managing user access. By default, NGINX Instance Manager uses basic authentication, requiring you to send your username and password with each request to confirm your identity. When logging in for the first time, use the default `admin` account and password. After that, you can create additional user accounts. Instructions for adding users and setting passwords are provided below.

--- a/content/nim/admin-guide/authentication/oidc/getting-started.md
+++ b/content/nim/admin-guide/authentication/oidc/getting-started.md
@@ -14,6 +14,10 @@ We recommend using OpenID Connect (OIDC) as the preferred authentication method 
 
 NGINX Instance Manager’s implementation of OIDC is designed to work with any Identity Provider (IdP) that supports the OIDC protocol. The instructions below are general and can be applied to any IdP.
 
+{{<call-out "important" "Which authentication method is active?" >}}
+By default, NGINX Instance Manager uses basic authentication. OIDC must be explicitly configured. When OIDC is enabled, basic authentication is disabled for all users, including the default `admin` user. In this case, users must use bearer tokens (obtained via OIDC login) for API and UI access. If you have not enabled OIDC or want to revert, see the [Set up basic authentication guide]({{< ref "/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md" >}}). Before following API examples, check which authentication method is active in your environment.
+{{</call-out>}}
+
 {{<call-out "tip" "Do you need to configure a specific IdP?">}}To learn how to configure OIDC with a specific identity provider, refer to the linked topics in the [Set up specific IdPs for OIDC](#oidc-specific-idps) section at the bottom of this page.{{</call-out>}}
 
 {{<call-out "important" "OIDC is not supported in forward-proxy mode" "fa-solid fa-triangle-exclamation" >}}OpenID Connect (OIDC) authentication is not supported when NGINX Instance Manager is running in [forward-proxy mode]({{< ref "nim/system-configuration/configure-forward-proxy.md" >}}). OIDC is configured on the NGINX Plus layer and cannot pass authentication requests through a forward proxy.{{</call-out>}}


### PR DESCRIPTION
Attempt to resolve issue 113

The user has identified a documentation gap: there is no clear, centralized explanation in the NGINX Instance Manager (NIM) docs about when to use basic authentication versus OIDC bearer tokens for API access. This leads to confusion, especially since API examples in some sections (e.g., WAF config management) only show bearer token usage, which fails for default ("vanilla") NIM deployments that use basic auth by default.

The user proposes adding an introductory explanation at the main authentication documentation entry point, clarifying:
- Which authentication method is the default (basic auth).
- When each method is required (basic auth for default installs, OIDC bearer tokens when OIDC is configured).
- That API examples should show both methods where appropriate.

Reviewing the potential documents, the following are relevant:
1. `content/nim/admin-guide/authentication/basic-auth/set-up-basic-authentication.md` – covers basic auth, but does not explain the relationship to OIDC or when to use which method.
2. `content/nim/admin-guide/authentication/oidc/getting-started.md` – covers OIDC, but does not clarify the default or how it interacts with basic auth.
3. `content/includes/nim/admin-guide/auth/basic-auth-api-requests.md` – gives a basic auth API example, but does not mention OIDC or the context for choosing between them.

The main entry point for authentication in the docs is likely a higher-level page (e.g., `content/nim/admin-guide/authentication/`), but this is missing or a placeholder. Therefore, the best place to add the requested overview is at the top of the basic auth setup guide, with cross-links to OIDC, and a new section or callout in the OIDC guide referencing the default and how to switch.

Additionally, API examples in WAF and other API-related docs should be updated to show both authentication methods, but this is outside the scope of the provided potential documents. However, the basic auth and OIDC guides should reference that users must use the correct method for their deployment, and that API examples may differ depending on the authentication method configured.

Therefore, the plan is:
- Update the basic auth setup guide to include a prominent section at the top explaining the default authentication method, when to use basic auth vs. OIDC, and how to recognize which is active.
- Update the OIDC getting started guide to reference that OIDC disables basic auth, and to link back to the basic auth guide for users who have not enabled OIDC.
- Update the basic auth API example include to mention that OIDC bearer tokens are required if OIDC is enabled, and link to the OIDC guide for details.