### PR TITLE
Auto-generated PR: issue 610

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -24,7 +24,7 @@ worker_processes 1;
 
 ## Feature-Specific Configuration Files
 
-To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the <span style="white-space: nowrap;">**/etc/nginx/conf.d**</span> directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
+To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the **/etc/nginx/conf.d** directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
 
 ```nginx
 include conf.d/http;


### PR DESCRIPTION
Attempt to resolve issue 610

The user's intent is to modernize and clean up the NGINX documentation by removing unnecessary inline `<span>` tags used for styling and replacing them with standard Markdown formatting (e.g., `**bold**`, `` `inline code` ``, `_italics_`). The issue content provides a clear rationale for this change, including maintainability, readability, and consistency with current documentation standards.

To address this, we need to identify which documents among the provided candidates actually contain inline `<span>` tags used for styling. Upon reviewing the potential documents, the following is observed:

- `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` contains at least one instance of a `<span>` tag used for styling: `<span style="white-space: nowrap;">**/etc/nginx/conf.d**</span>`. This is exactly the kind of usage the issue describes.
- The other documents (such as `content/nap-waf/v5/configuration-guide/configuration.md`, `CONTRIBUTING_DOCS.md`, `CONTRIBUTING.md`, templates, and proposals) do not appear to contain any inline `<span>` tags for styling, or are templates/guidelines that do not include actual documentation content with such tags.

Therefore, only `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` requires an update. The plan should be to remove the `<span>` tags and replace the styling with appropriate Markdown formatting, ensuring the text remains visually clear and semantically correct (e.g., using bold for directory names, and ensuring "no-wrap" is not needed due to modern CSS).