### PR TITLE
Auto-generated PR: issue 22

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -77,6 +77,8 @@ These archetypes are adapted from some existing [templates](/templates/): please
 
 ### Basic Markdown formatting
 
+> **Note:** Do not use inline HTML `<span>` tags or other inline HTML for styling. All inline styling should be accomplished using Markdown formatting (bold, italics, inline code) as described below. This improves maintainability, readability, and consistency across the documentation.
+
 There are multiple ways to format text: for consistency and clarity, these are our conventions:
 
 - Bold: Two asterisks on each side - `**Bolded text**`.


### PR DESCRIPTION
Attempt to resolve issue 22

The user's intent is to remove all inline <span> tags used solely for styling from the NGINX documentation and replace their effects with appropriate Markdown formatting (bold, inline code, italics). This is to simplify maintenance, improve readability, and ensure consistency with documentation standards.

Reviewing the provided potential documents, none of them appear to contain actual inline <span> tags in their current content. Instead, these files are either templates, style guides, or meta-documentation (such as contributing guidelines, archetype templates, or repository overviews). However, the "CONTRIBUTING_DOCS.md" file contains a section on Markdown formatting conventions, which is relevant to the new standard of not using inline <span> tags and instead using Markdown for styling.

To ensure future contributors do not reintroduce <span> tags, it would be beneficial to update "CONTRIBUTING_DOCS.md" to explicitly state that inline HTML <span> tags for styling should not be used, and that all styling should be done with Markdown formatting. This will reinforce the new standard and help prevent regressions.

The other documents (archetype templates, glossary, OSS components, how-to template, and repository README) do not need to be updated, as they either do not discuss formatting practices or are not intended to provide style guidance.