### PR TITLE
Auto-generated PR: issue 22

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -24,7 +24,7 @@ worker_processes 1;
 
 ## Feature-Specific Configuration Files
 
-To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the <span style="white-space: nowrap;">**/etc/nginx/conf.d**</span> directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
+To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the `/etc/nginx/conf.d` directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
 
 ```nginx
 include conf.d/http;


### PR DESCRIPTION
Attempt to resolve issue 22

The user's intent is to remove all unnecessary inline `<span>` tags used for styling from the NGINX documentation and replace them with standard Markdown formatting (bold, italics, inline code) for consistency, maintainability, and readability. The issue content provides a clear rationale and specific examples of the problem, as well as the desired solution.

Reviewing the potential documents, only one document among the candidates contains an actual instance of an inline `<span>` tag used for styling:

- `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` contains: `<span style="white-space: nowrap;">**/etc/nginx/conf.d**</span>`

The other documents do not contain any inline `<span>` tags or are templates, style guides, or meta-documents that do not include such HTML. Therefore, only the first document requires an update.

The plan for the change is to:
- Remove the `<span>` tag and its style attribute.
- Replace the content with the appropriate Markdown formatting, in this case, simply using `**/etc/nginx/conf.d**` (bold) and, if necessary, ensuring that the "no-wrap" intent is preserved by context or by using backticks for inline code if it is a path (i.e., `` `/etc/nginx/conf.d` ``), as per the documentation standards.

Given the context, the path should likely be formatted as inline code rather than bold, so the replacement should be `` `/etc/nginx/conf.d` ``.

No other documents in the provided list require changes.