### PR TITLE
Auto-generated PR: issue 22

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -24,7 +24,7 @@ worker_processes 1;
 
 ## Feature-Specific Configuration Files
 
-To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the <span style="white-space: nowrap;">**/etc/nginx/conf.d**</span> directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
+To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the **/etc/nginx/conf.d** directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
 
 ```nginx
 include conf.d/http;


### PR DESCRIPTION
Attempt to resolve issue 22

The issue is about removing all inline `<span>` tags used solely for styling from the NGINX documentation and replacing their effects with standard Markdown formatting (e.g., `**bold**`, inline code, `_italics_`). The rationale is to simplify the documentation source, improve maintainability, and ensure consistency with current standards.

Reviewing the potential documents, only one document contains an actual instance of an inline `<span>` tag used for styling:

- `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` contains: `<span style="white-space: nowrap;">**/etc/nginx/conf.d**</span>`

The other documents are either templates, guidelines, proposals, or do not contain any inline `<span>` tags for styling.

Therefore, only `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` needs to be updated. The plan is to remove the `<span>` tag and use Markdown formatting to achieve the intended effect (in this case, likely to keep the directory name together and bolded, which can be handled by just using `**/etc/nginx/conf.d**` or possibly backticks for inline code if appropriate).

No changes are needed for the other documents.