### PR TITLE
Auto-generated PR: issue 22

### DIFF
--- a/.cloudcannon/schemas/concept.md
+++ b/.cloudcannon/schemas/concept.md
@@ -1,4 +1,5 @@
 ---
+# Do not use inline HTML (e.g., <span> tags) for styling. Use Markdown formatting (e.g., **bold**, `inline code`, _italics_) instead.
 title: 
 # Remove or change to false to turn off the right-hand in-page ToC
 toc: true

--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -77,6 +77,8 @@ These archetypes are adapted from some existing [templates](/templates/): please
 
 ### Basic Markdown formatting
 
+> **Important**: Do not use inline HTML (such as `<span>` tags) for styling text. All formatting should be done using Markdown syntax (bold, italics, inline code). Inline HTML for styling is prohibited except where absolutely necessary for technical reasons.
+
 There are multiple ways to format text: for consistency and clarity, these are our conventions:
 
 - Bold: Two asterisks on each side - `**Bolded text**`.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -13,6 +13,7 @@ nd-product:
 ---
 
 [//]: # "These are Markdown comments to guide you through document structure. Remove them as you go, as well as any unnecessary sections."
+[//]: # "Do NOT use inline HTML (such as <span> tags) for styling. Use Markdown formatting (e.g., **bold**, _italics_, inline code) for all styling and emphasis."
 [//]: # "Use underscores for _italics_, and double asterisks for **bold**."
 [//]: # "Backticks are for `monospace`, used sparingly and reserved mostly for executable names - they can cause formatting problems. Avoid them in tables: use italics instead."
 

--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -24,7 +24,7 @@ worker_processes 1;
 
 ## Feature-Specific Configuration Files
 
-To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the <span style="white-space: nowrap;">**/etc/nginx/conf.d**</span> directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
+To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the `/etc/nginx/conf.d` directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
 
 ```nginx
 include conf.d/http;

--- a/templates/how-to/guide-how-to.md
+++ b/templates/how-to/guide-how-to.md
@@ -47,6 +47,8 @@ Before you start working on your how-tos, identify:
 - Use conditional imperatives. If you want x, do y. To achieve w, do z.
 - Do not explain concepts.
 - Sometimes it's helpful to occasionally provide links to supporting pieces of documentation for more information.Especially, when the user might need a link to supporting background or [conceptual](https://gitlab.com/tgdp/templates/-/tree/main/explanation) information and/or [reference](https://gitlab.com/tgdp/templates/-/tree/main/reference) materials. However, avoid providing too many links within the guide. Keep your users on a single page as much as possible and provide links to additional resources at the bottom of the page.
+
+- **Do not use inline HTML (such as `<span>` tags) for styling.** All formatting should use Markdown syntax: use `**bold**` for UI labels and key terms, backticks for inline code, and `_italics_` if needed. This ensures consistency, readability, and maintainability across documentation.
 - Avoid over-documenting multiple ways of achieving the same task. If there is more than one way to complete a given task, pick and only document the most common or recommended method of completing the task. Additional methods should be omitted or mentioned by providing a link or reference document. 
 - Avoid writing edge cases at the boundaries of your application's capability.
 - Always ensure that the steps provided in your how-to guide are technically accurate. Test your how-to instructions from start to finish so that you can uncover omitted steps, incorrect details, steps out of order, and information gaps that block users. If it's not possible to test it yourself, have a developer or subject matter expert demonstrate the step to you and record the session, if possible.


### PR DESCRIPTION
Attempt to resolve issue 22

The user's request is to systematically remove all inline `<span>` tags used solely for styling from the NGINX documentation, replacing them with equivalent Markdown formatting (bold, italics, inline code). This is to improve maintainability, readability, and consistency with current documentation standards. The issue content provides a clear rationale and examples, and the request is for both a content cleanup and an update to documentation guidelines.

Reviewing the potential documents:
1. `content/nginx/admin-guide/basic-functionality/managing-configuration-files.md` – This file contains at least one instance of a `<span>` tag used for styling (e.g., `<span style="white-space: nowrap;">**/etc/nginx/conf.d**</span>`). This is a direct target for the requested change.
2. `content/ossc.md` – No evidence of `<span>` tags or inline styling; this is a license acknowledgments page and is not relevant.
3. `documentation/README.md` – No evidence of `<span>` tags or inline styling; this is a general repo readme.
4. `CONTRIBUTING_DOCS.md` – This is the contributing guidelines for writers. While it does not appear to contain `<span>` tags, it is the appropriate place to update the guidelines to explicitly instruct contributors to avoid inline HTML for styling and to use Markdown formatting instead.
5. `templates/how-to/guide-how-to.md` – This is a template for how-to guides. It does not contain `<span>` tags, but updating it to reinforce Markdown formatting conventions would help prevent future use of inline HTML.
6. `.cloudcannon/schemas/concept.md` – This is a schema/template for concept docs. No evidence of `<span>` tags or inline styling, but could be updated to reinforce Markdown formatting.
7. `documentation/proposals/DOP-001.md` – This is a proposal document, not a style or content guideline, and does not appear to use `<span>` tags.
8. `CONTRIBUTING.md` – This is the general contributing guidelines. It references the style guide but does not itself contain formatting rules; it could link to the updated style guidance.
9. `archetypes/default.md` – This is a template for new docs. It already instructs users to use Markdown for bold/italics, but could be updated to explicitly discourage inline HTML for styling.

Therefore, the plan should:
- Update all content files that currently use `<span>` tags for styling (e.g., `managing-configuration-files.md`) to remove those tags and replace them with Markdown.
- Update the contributing guidelines and templates to explicitly instruct against using inline HTML for styling and to use Markdown formatting instead, ensuring future consistency.