### PR TITLE
Auto-generated PR: issue 22

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -24,7 +24,7 @@ worker_processes 1;
 
 ## Feature-Specific Configuration Files
 
-To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the <span style="white-space: nowrap;">**/etc/nginx/conf.d**</span> directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
+To make the configuration easier to maintain, we recommend that you split it into a set of feature‑specific files stored in the `/etc/nginx/conf.d` directory and use the [include](https://nginx.org/en/docs/ngx_core_module.html#include) directive in the main **nginx.conf** file to reference the contents of the feature‑specific files.
 
 ```nginx
 include conf.d/http;


### PR DESCRIPTION
Attempt to resolve issue 22

The user's intent is to remove all unnecessary inline `<span>` tags used for styling from the NGINX documentation and replace them with appropriate Markdown formatting (bold, italics, inline code) to improve maintainability and consistency. The issue content provides a clear rationale and example, and specifies that this is a systematic update across all affected documentation files.

Reviewing the potential documents, only one file (`content/nginx/admin-guide/basic-functionality/managing-configuration-files.md`) contains an actual instance of an inline `<span>` tag used for styling:
- In the section "Feature-Specific Configuration Files", the directory path `/etc/nginx/conf.d` is wrapped in a `<span style="white-space: nowrap;">...</span>`. This is a legacy artifact from previous publishing systems and should be replaced with Markdown formatting, likely as inline code (``/etc/nginx/conf.d``) to match documentation standards.

The other documents are templates, guidelines, or do not contain any inline `<span>` tags for styling. Therefore, only the above file requires an update at this time.