### PR TITLE
Documentation Update for Issue #29

### DIFF
--- a/content/agent/technical-specifications.md
+++ b/content/agent/technical-specifications.md
@@ -67,4 +67,4 @@ Minimum system sizing recommendations for NGINX Agent:
 
 ## Logging
 
-NGINX Agent utilizes log files and formats to collect metrics. Increasing the log formats and instance counts will result in increased log file sizes. To prevent system storage issues due to a growing log directory, it is recommended to add a separate partition for `/var/log/nginx-agent` and enable [log rotation](http://nginx.org/en/docs/control.html#logs).
+NGINX Agent utilizes log files and formats to collect metrics. Increasing the log formats and instance counts will result in increased log file sizes. To prevent system storage issues due to a growing log directory, add a separate partition for `/var/log/nginx-agent` and enable [log rotation](http://nginx.org/en/docs/control.html#logs).

--- a/content/nginx-one/about.md
+++ b/content/nginx-one/about.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-The F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
+F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
 
 ## Benefits and key features
 


### PR DESCRIPTION
Attempt to resolve issue 29

The user's intent is to ensure that all documentation consistently follows the style guide rules for product names: specifically, not using articles ("the", "a", "an") before product names and using the correct capitalization (e.g., "NGINX One Console" not "NGINX One console"). The issue content references the style guide and provides examples of incorrect usage, emphasizing the need for consistency and professionalism.

Reviewing the potential documents, several contain product names in their titles, descriptions, and body content. For example:
- "content/_index.md" (site landing page) references "F5 NGINX products".
- "content/nginx-one/glossary.md" references "F5 NGINX One Console", "NGINX One", "NGINX Agent", "NGINX Plus", etc.
- "content/agent/technical-specifications.md" references "NGINX Agent", "NGINX One Console", "NGINX Gateway Fabric", "NGINX Plus", "NGINX Ingress Controller", "NGINX Instance Manager", etc.
- "content/nginx-one/_index.md" and "content/nginx-one/about.md" reference "F5 NGINX One Console", "NGINX One Console", and other product names in headings, cards, and descriptions.

These documents are likely to contain instances where articles are incorrectly used before product names or where capitalization is inconsistent. The other files (templates, archetypes, and some admin guides) are either templates, guides for contributors, or do not contain product names in their visible content, so they are less likely to require changes for this specific issue.

Therefore, the plan should focus on the main product documentation pages and glossaries, where product names are most frequently used and visible to users.