### PR TITLE
Documentation Update for Issue #29

### DIFF
--- a/content/agent/technical-specifications.md
+++ b/content/agent/technical-specifications.md
@@ -67,4 +67,4 @@ Minimum system sizing recommendations for NGINX Agent:
 
 ## Logging
 
-NGINX Agent utilizes log files and formats to collect metrics. Increasing the log formats and instance counts will result in increased log file sizes. To prevent system storage issues due to a growing log directory, it is recommended to add a separate partition for `/var/log/nginx-agent` and enable [log rotation](http://nginx.org/en/docs/control.html#logs).
+NGINX Agent utilizes log files and formats to collect metrics. Increasing the log formats and instance counts will result in increased log file sizes. To prevent system storage issues due to a growing log directory, add a separate partition for `/var/log/nginx-agent` and enable [log rotation](http://nginx.org/en/docs/control.html#logs).

--- a/content/nginx-one/about.md
+++ b/content/nginx-one/about.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-The F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
+F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
 
 ## Benefits and key features
 

--- a/content/nginx-one/changelog.md
+++ b/content/nginx-one/changelog.md
@@ -28,7 +28,7 @@ h2 {
 
 </style>
 
-Stay up-to-date with what's new and improved in the F5 NGINX One Console.
+Stay up-to-date with what's new and improved in F5 NGINX One Console.
 
 ## May 19, 2025
 
@@ -75,7 +75,7 @@ It allows you to:
 
 ### Manage certificates with Config Sync Groups
 
-With the NGINX One Console, you can now manage certificate deployment in Config Sync Groups.
+With NGINX One Console, you can now manage certificate deployment in Config Sync Groups.
 
 You can:
 
@@ -88,7 +88,7 @@ For more information, including warnings about risks, see our documentation on h
 
 ### Revert a configuration
 
-Using the NGINX One Console you can now:
+Using NGINX One Console you can now:
 
 - See a history of changes to the configuration on an instance or a Config Sync Group, as well as the content of the previous five configs published to that object
 - Review the differences between the current and other saved configurations
@@ -96,13 +96,13 @@ Using the NGINX One Console you can now:
 
 ### F5 AI Assistant
 
-In the F5 NGINX One Console, you can now select lines from your configuration files, and then select **Explain with AI**. The F5 AI Assistant explains those lines based on the official NGINX documentation.
+In F5 NGINX One Console, you can now select lines from your configuration files, and then select **Explain with AI**. The F5 AI Assistant explains those lines based on the official NGINX documentation.
 
 ## November 7, 2024
 
 ### Certificates
 
-From the NGINX One Console you can now:
+From NGINX One Console you can now:
 
 - Monitor all certificates configured for use by your connected NGINX Instances.
 - Ensure that your certificates are current and correct.
@@ -114,7 +114,7 @@ For more information, see the full documentation on how you can [Manage Certific
 
 ### Config Sync Groups
 
-Config Sync Groups are now available in the F5 NGINX One Console. This feature allows you to manage and synchronize NGINX configurations across multiple instances as a single entity, ensuring consistency and simplifying the management of your NGINX environment.
+Config Sync Groups are now available in F5 NGINX One Console. This feature allows you to manage and synchronize NGINX configurations across multiple instances as a single entity, ensuring consistency and simplifying the management of your NGINX environment.
 
 For more information, see the full documentation on [Managing Config Sync Groups]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md" >}}).
 
@@ -159,7 +159,7 @@ We've updated the **Instance Details** and **Data Plane Keys** pages to make it 
 
 ## February 6, 2024
 
-### Welcome to the NGINX One EA preview
+### Welcome to NGINX One EA preview
 
 We're thrilled to introduce NGINX One, an exciting addition to our suite of NGINX products. Designed with efficiency and ease of use in mind, NGINX One offers an innovative approach to managing your NGINX instances.
 

--- a/templates/installation-guide/template-installation-guide.md
+++ b/templates/installation-guide/template-installation-guide.md
@@ -12,7 +12,7 @@
 
 ## Installation types
 
-This guide explains the steps and instructions required to install {product name} on supported operating systems. It also explains how to configure, start, and uninstall {product name}}.
+This guide explains the steps and instructions required to install {product name} on supported operating systems. It also explains how to configure, start, and uninstall {product name}.
 
 {Include a table to capture the different installation types, such as:
 
@@ -43,7 +43,7 @@ This guide explains the steps and instructions required to install {product name
 
 |      | **Process**  | **More information** |
 | ---- | ------------ | -------------------- |
-| 1. | Before installing, check the system requirements to ensure your computer is supported in the latest version of {product name}. | {Link to relevant documents}        |
+| 1. | Before installing, check the system requirements to ensure your computer is supported in latest version of {product name}. | {Link to relevant documents}        |
 | 2. | Check the system prerequisites to install all the required {software,  dependencies, tools.}.    | {Link to relevant documents}                          |
 | 3. | {List additional steps.}          | {Link to relevant documents}                                    |
 | 4. | Verify that the installation was successful.  | {Link to relevant documents} |


### PR DESCRIPTION
Attempt to resolve issue 29

The user's intent is to ensure that all documentation consistently follows the style guide regarding product naming conventions, specifically:
- Do not use articles ("the", "a", "an") before product names.
- Ensure correct capitalization of product names (e.g., "NGINX One Console" not "NGINX One console").

The issue content references the style guide and provides examples of incorrect usage, such as "the NGINX Agent" or "NGINX One console". The style guide (templates/style-guide.md) explicitly states these rules.

Reviewing the potential documents, several contain product names in their titles, descriptions, and body content. For example:
- content/nginx-one/_index.md, content/nginx-one/about.md, content/nginx-one/changelog.md, and content/nginx-one/glossary.md all reference "NGINX One Console" and other product names.
- content/agent/technical-specifications.md references "NGINX Agent", "NGINX One Console", "NGINX Plus", etc.
- content/nim/_index.md references "NGINX Instance Manager".
- The templates and contributing docs may also reference product names as examples or in boilerplate.

To comply with the style guide, each document must be reviewed for:
1. Incorrect use of articles before product names (e.g., "the NGINX One Console", "an NGINX Agent").
2. Incorrect capitalization of product names (e.g., "NGINX One console" instead of "NGINX One Console").
3. Consistency in product naming throughout the document.

Documents that are templates (e.g., templates/reference/template-reference.md, templates/installation-guide/template-installation-guide.md) or guides for contributors (e.g., CONTRIBUTING_DOCS.md) may use product names as examples, so they should also be checked for style compliance to avoid propagating incorrect usage.

Therefore, all user-facing documentation and templates that mention product names should be updated to ensure compliance with the style guide.