### PR TITLE
Documentation Update for Issue #29

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -17,8 +17,9 @@ nd-product:
 [//]: # "Backticks are for `monospace`, used sparingly and reserved mostly for executable names - they can cause formatting problems. Avoid them in tables: use italics instead."
 
 [//]: # "Begin each document with a sentence or two explaining what the purpose of the guide is, and what high-level actions to expect. No need to adhere precisely the example text given anywhere in this template."
+[//]: # "Do not use articles (the, a, an) before product names. Always capitalize product names correctly, e.g., NGINX, NGINX One Console. See the style guide for details."
 
-This guide explains how to <X> with <Y>. In involves the use of <A>, <B> and <C>, demonstrating how <X> works with an example <Z>.
+This guide explains how to <X> with <Y>. It involves the use of <A>, <B>, and <C>, demonstrating how <X> works with an example <Z>.
 
 ## Before you begin
 

--- a/content/nginx-one/_index.md
+++ b/content/nginx-one/_index.md
@@ -56,7 +56,7 @@ cascade:
   {{</ card-section >}}
   {{< card-section title="Modern App Delivery">}}
     {{< card title="NGINX Plus" titleUrl="/nginx" icon="NGINX-Plus-product-icon-RGB">}}
-      The all-in-one load balancer, reverse proxy, web server, content cache, and API gateway. 
+      All-in-one load balancer, reverse proxy, web server, content cache, and API gateway. 
     {{</ card >}}
     {{< card title="NGINX Open Source" titleUrl="https://nginx.org" icon="NGINX-product-icon">}}
       The open source all-in-one load balancer, content cache, and web server 

--- a/content/nginx-one/about.md
+++ b/content/nginx-one/about.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-The F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
+F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
 
 ## Benefits and key features
 

--- a/content/nginx-one/changelog.md
+++ b/content/nginx-one/changelog.md
@@ -28,7 +28,7 @@ h2 {
 
 </style>
 
-Stay up-to-date with what's new and improved in the F5 NGINX One Console.
+Stay up-to-date with what's new and improved in F5 NGINX One Console.
 
 ## May 19, 2025
 
@@ -75,7 +75,7 @@ It allows you to:
 
 ### Manage certificates with Config Sync Groups
 
-With the NGINX One Console, you can now manage certificate deployment in Config Sync Groups.
+With NGINX One Console, you can now manage certificate deployment in Config Sync Groups.
 
 You can:
 
@@ -88,7 +88,7 @@ For more information, including warnings about risks, see our documentation on h
 
 ### Revert a configuration
 
-Using the NGINX One Console you can now:
+Using NGINX One Console you can now:
 
 - See a history of changes to the configuration on an instance or a Config Sync Group, as well as the content of the previous five configs published to that object
 - Review the differences between the current and other saved configurations
@@ -96,13 +96,13 @@ Using the NGINX One Console you can now:
 
 ### F5 AI Assistant
 
-In the F5 NGINX One Console, you can now select lines from your configuration files, and then select **Explain with AI**. The F5 AI Assistant explains those lines based on the official NGINX documentation.
+In F5 NGINX One Console, you can now select lines from your configuration files, and then select **Explain with AI**. The F5 AI Assistant explains those lines based on the official NGINX documentation.
 
 ## November 7, 2024
 
 ### Certificates
 
-From the NGINX One Console you can now:
+From NGINX One Console you can now:
 
 - Monitor all certificates configured for use by your connected NGINX Instances.
 - Ensure that your certificates are current and correct.
@@ -114,7 +114,7 @@ For more information, see the full documentation on how you can [Manage Certific
 
 ### Config Sync Groups
 
-Config Sync Groups are now available in the F5 NGINX One Console. This feature allows you to manage and synchronize NGINX configurations across multiple instances as a single entity, ensuring consistency and simplifying the management of your NGINX environment.
+Config Sync Groups are now available in F5 NGINX One Console. This feature allows you to manage and synchronize NGINX configurations across multiple instances as a single entity, ensuring consistency and simplifying the management of your NGINX environment.
 
 For more information, see the full documentation on [Managing Config Sync Groups]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md" >}}).
 
@@ -159,7 +159,7 @@ We've updated the **Instance Details** and **Data Plane Keys** pages to make it 
 
 ## February 6, 2024
 
-### Welcome to the NGINX One EA preview
+### Welcome to NGINX One EA preview
 
 We're thrilled to introduce NGINX One, an exciting addition to our suite of NGINX products. Designed with efficiency and ease of use in mind, NGINX One offers an innovative approach to managing your NGINX instances.
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,6 @@
 # NGINX Documentation repository 
 
-This directory contains the documentation for the NGINX Documentation repository.
+This directory contains documentation for NGINX Documentation repository.
 
 It's used by the DocOps team to record how we configure our tools and instructions for certain precise tasks.
 


### PR DESCRIPTION
Attempt to resolve issue 29

The issue is about enforcing the style guide rule that product names (such as "NGINX", "NGINX One Console", "NGINX Plus", etc.) should not be preceded by articles ("the", "a", "an") and must use correct capitalization (e.g., "NGINX One Console" not "NGINX One console"). The user wants all documentation to be consistent with this rule.

From the provided potential documents, several contain product names in their titles, descriptions, and body text. Some documents, such as glossaries, technical specifications, and landing pages, are especially likely to mention product names frequently. Others, like templates and archetypes, serve as the basis for new documentation and must also model correct usage.

To address the issue, each document must be reviewed for:
- Incorrect use of articles before product names (e.g., "the NGINX Agent", "an NGINX", "a NGINX One Console").
- Incorrect capitalization of product names (e.g., "NGINX One console" instead of "NGINX One Console").
- Consistency in product name usage, especially in tables, headings, and callouts.

Documents that are templates or archetypes must be updated to model correct usage, as they influence future documentation. Glossaries and landing pages must be especially precise, as they are reference points for terminology.

Some documents (like README.md, documentation/README.md, and CONTRIBUTING_DOCS.md) may only mention product names in passing, but should still be checked for compliance, as they are often referenced by contributors.

Therefore, the plan is to:
- Review and update all user-facing documentation, glossaries, landing pages, and templates/archetypes for correct product name usage and capitalization.
- Ensure that all templates and archetypes model the correct style, so new documentation will be consistent.
- Update any instance where articles are used before product names or where capitalization is incorrect.