### PR TITLE
Documentation Update for Issue #29

### DIFF
--- a/content/agent/overview.md
+++ b/content/agent/overview.md
@@ -40,7 +40,7 @@ When running alongside an open source instance of NGINX, NGINX Agent requires th
 
 ### NGINX Plus
 
-For NGINX Agent to work properly with an NGINX Plus instance, the API needs to be configured in that instance's nginx.conf. See [Instance Metrics Overview](https://docs.nginx.com/nginx-instance-manager/monitoring/overview-metrics/) for more details. Once NGINX Plus is configured with the `/api/` endpoint, the Agent will automatically use it on startup.
+For NGINX Agent to work properly with NGINX Plus instance, the API needs to be configured in that instance's nginx.conf. See [Instance Metrics Overview](https://docs.nginx.com/nginx-instance-manager/monitoring/overview-metrics/) for more details. Once NGINX Plus is configured with the `/api/` endpoint, the Agent will automatically use it on startup.
 
 ## Event Notifications
 

--- a/content/nginx-one/about.md
+++ b/content/nginx-one/about.md
@@ -8,7 +8,7 @@ type:
 - reference
 ---
 
-The F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
+F5 NGINX One Console makes it easy to manage NGINX instances across locations and environments. The console lets you monitor and control your NGINX fleet from one place—you can check configurations, track performance metrics, identify security vulnerabilities, manage SSL certificates, and more.
 
 ## Benefits and key features
 

--- a/content/nim/releases/known-issues.md
+++ b/content/nim/releases/known-issues.md
@@ -108,12 +108,12 @@ In NGINX Instance Manager v2.19.0, publishing an NGINX App Protect WAF policy fr
 
 #### Workaround
 
-1. Download the NGINX repository certificate and key:
+1. Download NGINX repository certificate and key:
    - Log in to [MyF5](https://account.f5.com/myf5).
    - Go to **My Products and Plans > Subscriptions**.
    - Download the SSL certificate (*nginx-repo.crt*) and private key (*nginx-repo.key*) for your NGINX App Protect subscription.
 
-2. Upload the certificate and key using the NGINX Instance Manager web interface:
+2. Upload certificate and key using NGINX Instance Manager web interface:
    - Go to **Settings > NGINX Repo Connect**.
    - Select **Add Certificate**.
    - Choose **Select PEM files** or **Manual entry**.
@@ -255,7 +255,7 @@ If NGINX Agent is configured to monitor NGINX App Protect before App Protect is 
 
 #### Workaround
 
-Edit the "/etc/nginx-agent/nginx-agent.conf" file and configure "precompiled_publication" as "false". Then restart the nginx-agent process running `sudo systemctl restart nginx-agent`.
+Edit "/etc/nginx-agent/nginx-agent.conf" and configure "precompiled_publication" as "false". Then restart nginx-agent by running `sudo systemctl restart nginx-agent`.
 
 ---
 
@@ -279,7 +279,7 @@ After adding a license, some NGINX Management Suite features might be disabled, 
 
 #### Workaround
 
-Restart NGINX Management Suite to make all the features available for use. To restart NGINX Management Suite, open a terminal on the host and run the command:
+Restart NGINX Management Suite to make all features available for use. To restart NGINX Management Suite, open a terminal on the host and run the command:
 
 ```shell
 sudo systemctl restart nms
@@ -742,7 +742,7 @@ This error can occur when there is a desyncronization between the NGINX Agent an
 
 #### Workaround
 
-Restart the NGINX Agent:
+Restart NGINX Agent:
 
 ``` bash
 sudo systemctl restart nginx-agent


### PR DESCRIPTION
Attempt to resolve issue 29

The user's intent is to ensure that all documentation consistently follows the style guide regarding product names: specifically, not using articles ("the", "a", "an") before product names and using the correct capitalization (e.g., "NGINX One Console" instead of "NGINX One console"). The issue content references the style guide and provides examples of incorrect usage, such as "an NGINX" or "the NGINX Agent", and inconsistent capitalization like "NGINX One console".

The potential documents include landing pages, glossaries, technical specifications, product overviews, and other reference materials for NGINX products. These documents are likely to contain multiple references to product names, and some already show inconsistent usage (e.g., "the F5 NGINX One Console", "the console", "the NGINX fleet", etc.).

To address the issue, each document that refers to NGINX products must be reviewed for:
- Removal of articles ("the", "a", "an") before product names.
- Correct capitalization of product names (e.g., "NGINX One Console", "NGINX Agent", "NGINX Plus", etc.).
- Consistency in product naming throughout the document.

Documents that are primarily legal notices, open source acknowledgments, or internal process documentation (e.g., LICENSE, OSSC, CONTRIBUTING_DOCS.md, documentation/README.md) are less likely to contain product name inconsistencies, but should still be checked if they mention product names.

The plan should focus on all user-facing documentation, especially landing pages, glossaries, technical specifications, and product overviews, as these are most likely to contain product name references and are visible to end users.