### PR TITLE
Documentation Update for Issue #45

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
@@ -981,34 +981,53 @@ Prior to compiling NGINX Open Source from source, you need to install libraries 
 
 - [OpenSSL](https://www.openssl.org/) – Supports the HTTPS protocol. Required by the NGINX [SSL](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) module and others.
 
-  ```shell
-  wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./Configure darwin64-x86_64-cc --prefix=/usr
-  make
-  sudo make install
-  ```
+  > **Note:** The OpenSSL build process requires selecting the correct configuration target for your platform and architecture. Using the wrong target (e.g., building for Intel/x86_64 on Apple Silicon/ARM64) will result in build errors. For a full list of supported targets and detailed instructions, see the [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md) (especially the section on "Selecting the correct target").
 
-  Example for Ubuntu and Debian:
-  ```shell
-  wget https://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./config --prefix=/usr/local --openssldir=/usr/local/ssl
-  make -j$(nproc)
-  sudo make install
-  ```
+  #### MacOS
+  - **For MacOS (Intel/x86_64):**
+    ```shell
+    wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./Configure darwin64-x86_64-cc --prefix=/usr
+    make
+    sudo make install
+    ```
+    This command is for Intel-based Macs only.
 
-  Example for RHEL-based:
-  ```shell
-  curl -LO https://www.openssl.org/source/openssl-3.0.13.tar.gz
-  tar -zxf openssl-3.0.13.tar.gz
-  cd openssl-3.0.13
-  ./config --prefix=/usr/local --openssldir=/usr/local/ssl
-  make -j$(nproc)
-  sudo make install
-  ```
+  - **For MacOS (Apple Silicon/ARM64, e.g., M1/M2):**
+    ```shell
+    wget http://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./Configure darwin64-arm64-cc --prefix=/usr
+    make
+    sudo make install
+    ```
+    Use this command if you are on an Apple Silicon Mac (ARM64). If you are unsure of your architecture, run `uname -m` (should return `arm64` for Apple Silicon).
+
+  #### Linux
+  - **For most Linux distributions (x86_64/ARM64):**
+    ```shell
+    wget https://www.openssl.org/source/openssl-3.0.13.tar.gz
+    tar -zxf openssl-3.0.13.tar.gz
+    cd openssl-3.0.13
+    ./config --prefix=/usr/local --openssldir=/usr/local/ssl
+    make -j$(nproc)
+    sudo make install
+    ```
+    The `./config` script auto-detects your platform. For advanced or cross-compilation scenarios, consult the [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md) and use `./Configure <target>` as appropriate.
+
+  #### Windows/WSL
+  - **For Windows or Windows Subsystem for Linux (WSL):**
+    Building OpenSSL on Windows requires different steps and toolchains (e.g., Visual Studio, Perl, and NASM). Refer to the [OpenSSL INSTALL.md](https://github.com/openssl/openssl/blob/master/INSTALL.md#windows) for detailed Windows build instructions and supported targets.
+
+  > **Tip:** To see all available configuration targets, run:
+  > ```shell
+  > ./Configure LIST
+  > ```
+  > and consult the [Selecting the correct target](https://github.com/openssl/openssl/blob/master/INSTALL.md#selecting-the-correct-target) section in the OpenSSL documentation.
+
 
 ### Download the sources {#sources_download}
 


### PR DESCRIPTION
Attempt to resolve issue 45

The issue highlights that the current documentation for building OpenSSL as a dependency for compiling NGINX from source is unclear and potentially misleading for users on non-Intel MacOS, Apple Silicon (ARM64) Macs, Linux, and Windows/WSL. The OpenSSL build command shown (`./Configure darwin64-x86_64-cc --prefix=/usr`) is specific to Intel-based MacOS, but this is not explained, and no alternative instructions or guidance are provided for other platforms. The issue also requests a link to the official OpenSSL documentation for identifying the correct configuration target.

Reviewing the content of `content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md`, I see that:
- The OpenSSL build instructions are present in the "Install NGINX dependencies" section.
- There is a MacOS-specific command, but it is not labeled as such.
- There are example commands for Ubuntu/Debian and RHEL-based systems, but the distinction and guidance for Apple Silicon Macs, Windows/WSL, and general platform/architecture selection are missing.
- There is no link to the official OpenSSL INSTALL.md or guidance on how to select the correct configuration target.

No other document in the provided set is relevant to this issue; the rest are about modules, technical specs, or unrelated installation topics.

Therefore, only `content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md` needs to be updated. The plan should:
- Clearly label the MacOS Intel OpenSSL build command as such.
- Add guidance for Apple Silicon (ARM64) Macs, e.g., using `darwin64-arm64-cc`.
- Add a note or section for Linux and Windows/WSL users, explaining typical commands (e.g., `./config` for Linux, and reference to Windows build instructions).
- Add a link to the official OpenSSL INSTALL.md and explain how to find/select the correct configuration target for their platform.
- Optionally, split the OpenSSL build instructions into MacOS (Intel/ARM), Linux, and Windows/WSL subsections for clarity.