### PR TITLE
Documentation Update for Issue #46

### DIFF
--- a/content/nginx-one/glossary.md
+++ b/content/nginx-one/glossary.md
@@ -8,18 +8,30 @@ type:
 - reference
 ---
 
+This is the unified glossary for all NGINX products, including NGINX Open Source, NGINX Plus, NGINX One, and NGINX Ingress Controller. For broader industry terms, see the [F5 Glossary](https://www.f5.com/glossary).
+
 This glossary defines terms used in the F5 NGINX One Console and F5 Distributed Cloud.
 
 
 {{<bootstrap-table "table table-striped table-bordered">}}
-| Term        | Definition |
-|-------------|-------------|
-| **Config Sync Group** | A group of NGINX systems (or instances) with identical configurations. They may also share the same certificates. However, the instances in a Config Sync Group could belong to different systems and even different clusters. For more information, see this explanation of [Important considerations]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md#important-considerations" >}}) |
-| **Data Plane** | The data plane is the part of a network architecture that carries user traffic. It handles tasks like forwarding data packets between devices and managing network communication. In the context of NGINX, the data plane is responsible for tasks such as load balancing, caching, and serving web content. |
-| **Instance** | An instance is an individual system with NGINX installed. You can group the instances of your choice in a Config Sync Group. When you add an instance to NGINX One, you need to use a data plane key. |
-| **Namespace** | In F5 Distributed Cloud, a namespace groups a tenant’s configuration objects, similar to administrative domains. Every object in a namespace must have a unique name, and each namespace must be unique to its tenant. This setup ensures isolation, preventing cross-referencing of objects between namespaces. You'll see the namespace in the NGINX One Console URL as `/namespaces/<namespace name>/` |
-| **Staged Configurations** | Also known as **Staged Configs**. Allows you to save "work in progress." You can create it from scratch, an Instance, another Staged Config, or a Config Sync Group. It does _not_ have to be a working configuration until you publish it to an instance or a Config Sync Group. You can even manage your **Staged Configurations** through our [API]({{< ref "/nginx-one/api/api-reference-guide/#tag/StagedConfigs" >}}). |
-| **Tenant** | A tenant in F5 Distributed Cloud is an entity that owns a specific set of configuration and infrastructure. It is fundamental for isolation, meaning a tenant cannot access objects or infrastructure of other tenants. Tenants can be either individual or enterprise, with the latter allowing multiple users with role-based access control (RBAC). |
+| Term        | Definition | Product(s) |
+|-------------|-------------|-------------|
+| **Config Sync Group** | A group of NGINX systems (or instances) with identical configurations. They may also share the same certificates. However, the instances in a Config Sync Group could belong to different systems and even different clusters. For more information, see this explanation of [Important considerations]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md#important-considerations" >}}) | NGINX One |
+| **Data Plane** | The data plane is the part of a network architecture that carries user traffic. It handles tasks like forwarding data packets between devices and managing network communication. In the context of NGINX, the data plane is responsible for tasks such as load balancing, caching, and serving web content. | All |
+| **Instance** | An instance is an individual system with NGINX installed. You can group the instances of your choice in a Config Sync Group. When you add an instance to NGINX One, you need to use a data plane key. | NGINX One |
+| **Namespace** | In F5 Distributed Cloud, a namespace groups a tenant’s configuration objects, similar to administrative domains. Every object in a namespace must have a unique name, and each namespace must be unique to its tenant. This setup ensures isolation, preventing cross-referencing of objects between namespaces. You'll see the namespace in the NGINX One Console URL as `/namespaces/<namespace name>/` | NGINX One |
+| **Staged Configurations** | Also known as **Staged Configs**. Allows you to save "work in progress." You can create it from scratch, an Instance, another Staged Config, or a Config Sync Group. It does _not_ have to be a working configuration until you publish it to an instance or a Config Sync Group. You can even manage your **Staged Configurations** through our [API]({{< ref "/nginx-one/api/api-reference-guide/#tag/StagedConfigs" >}}). | NGINX One |
+| **Tenant** | A tenant in F5 Distributed Cloud is an entity that owns a specific set of configuration and infrastructure. It is fundamental for isolation, meaning a tenant cannot access objects or infrastructure of other tenants. Tenants can be either individual or enterprise, with the latter allowing multiple users with role-based access control (RBAC). | NGINX One |
+| **Ingress** | Refers to an Ingress Resource, a Kubernetes API object that allows access to Services within a cluster. Enables load balancing, content-based routing, and TLS/SSL termination. | NGINX Ingress Controller |
+| **Ingress Controller** | An application within a Kubernetes cluster that enables Ingress resources to function. NGINX Ingress Controller is an implementation of this. | NGINX Ingress Controller |
+| **Identity Provider (IdP)** | A service that authenticates users and verifies their identity for client applications. | OIDC, NGINX Plus |
+| **Protected Resource** | A resource hosted by the resource server that requires an access token to be accessed. | OIDC |
+| **Relying Party (RP)** | A client service required to verify user identity. In OIDC, NGINX Plus acts as the RP. | OIDC, NGINX Plus |
+| **JSON Web Token (JWT)** | An open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. | OIDC, NGINX Plus |
+| **ID Token** | Specific to OIDC, a JWT that provides information about the authentication operation’s outcome. | OIDC |
+| **Access Token** | Defined in OAuth2, this (optional) short lifetime token provides access to specific user resources as defined in the scope values in the request to the authorization server. | OIDC |
+| **Refresh Token** | From OAuth2 specs, a long-lived token used to obtain new access tokens. | OIDC |
+
 {{</bootstrap-table>}}
 
 ## Legal notice: Licensing agreements for NGINX products

--- a/content/nginx/admin-guide/security-controls/configuring-oidc.md
+++ b/content/nginx/admin-guide/security-controls/configuring-oidc.md
@@ -336,18 +336,7 @@ Upon successful sign-in, the IdP redirects you back to NGINX Plus, and you will 
 
 ## Glossary {#glossary}
 
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-| Term                    | Description                                        |
-|-------------------------|----------------------------------------------------|
-| Identity Provider (IdP) | A service that authenticates users and verifies their identity for client applications. |
-| Protected Resource      | A resource that is hosted by the resource server and requires an access token to be accessed. |
-| Relying Party (RP)      | A client service required to verify user identity. |
-| JSON Web Token (JWT)    | An open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. This information can be verified and trusted because it is digitally signed. |
-| ID Token                | Specific to OIDC, the primary use of the token in JWT format is to provide information about the authentication operation's outcome. |
-| Access Token            | Defined in OAuth2, this (optional) short lifetime token provides access to specific user resources as defined in the scope values in the request to the authorization server (can be a JSON token as well). |
-| Refresh Token           | Coming from OAuth2 specs, the token is usually long-lived and may be used to obtain new access tokens. |
-{{</bootstrap-table>}}
+For definitions of OIDC, SSO, and other NGINX-related terms, see the [NGINX Glossary](/nginx-one/glossary/).
 
 
 ## See Also {#see-also}

--- a/content/nic/glossary.md
+++ b/content/nic/glossary.md
@@ -5,26 +5,6 @@ title: Glossary
 weight: 10000
 ---
 
-This is a glossary of terms related to F5 NGINX Ingress Controller and Kubernetes as a whole.
-
----
-
-## Ingress {#ingress}
-
-_Ingress_ refers to an _Ingress Resource_, a Kubernetes API object which allows access to [Services](https://kubernetes.io/docs/concepts/services-networking/service/) within a cluster. They are managed by an [Ingress Controller]({{< ref "/nic/glossary.md#ingress-controller">}}).
-
-_Ingress_ resources enable the following functionality:
-
-- **Load balancing**, extended through the use of Services
-- **Content-based routing**, using hosts and paths
-- **TLS/SSL termination**, based on hostnames
-
-For additional information, please read the official [Kubernetes Ingress Documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/).
-
----
-
-## Ingress Controller {#ingress-controller}
-
-*Ingress Controllers* are applications within a Kubernetes cluster that enable [Ingress]({{< ref "/nic/glossary.md#ingress">}}) resources to function. They are not automatically deployed with a Kubernetes cluster, and can vary in implementation based on intended use, such as load balancing algorithms for Ingress resources.
-
-[The design of NGINX Ingress Controller]({{< ref "/nic/overview/design.md">}}) explains the technical details of NGINX Ingress Controller.
+:::note
+This glossary has been deprecated. All NGINX and NGINX Ingress Controller terms are now found in the unified NGINX glossary. Please refer to [the NGINX Glossary](https://docs.nginx.com/nginx-one/glossary/) for up-to-date definitions and terminology.
+:::


### PR DESCRIPTION
Attempt to resolve issue 46

The user wants to consolidate all NGINX-related glossary terms into a single, authoritative glossary to eliminate duplication and confusion. Currently, there are separate glossaries for NGINX One, NGINX Ingress Controller, and OIDC (within a guide), and there is also reference to the broader F5 glossary. The goal is to have one comprehensive glossary for all NGINX products, referenced consistently throughout the documentation.

From the potential documents, the following are relevant:
- `content/nginx-one/glossary.md`: The current NGINX One glossary, which is the most comprehensive and product-agnostic starting point.
- `content/nic/glossary.md`: The NGINX Ingress Controller glossary, which contains Kubernetes/Ingress-specific terms.
- The OIDC glossary is not a standalone document but a section within a guide, so its terms should be migrated into the new unified glossary.
- The F5 glossary is external and not part of the docs repo, but the unified glossary can link to it for broader industry terms.

To achieve the intent:
- All NGINX-related terms from the Ingress Controller glossary and the OIDC glossary section should be merged into the main glossary (likely `content/nginx-one/glossary.md`), which should be renamed and repositioned as the single source of truth for NGINX terminology.
- The Ingress Controller glossary page should be deprecated and replaced with a redirect or a note pointing to the unified glossary.
- The OIDC glossary section should be removed from the guide and replaced with a reference to the unified glossary.
- The unified glossary should be expanded to include all relevant terms, clearly indicating which terms are specific to certain products (e.g., Ingress Controller, OIDC, NGINX One, etc.) for clarity.
- All other documentation should be updated to reference the unified glossary.

Other documents in the list (such as product overviews, technical specs, etc.) do not contain glossaries and do not need to be updated for this change.