### PR TITLE
Documentation Update for Issue #51

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -86,6 +86,20 @@ There are multiple ways to format text: for consistency and clarity, these are o
 
 > **Note**: The ordered notation automatically enumerates lists when built by Hugo.
 
+#### Creating custom anchors in documentation
+
+To create custom anchors (link targets) in documentation, use Hugo's Markdown header syntax rather than raw HTML. Do **not** use `<a name="...">` tags, as these are not compatible with Hugo's rendering and may cause issues with navigation and styling.
+
+**Preferred syntax:**
+
+```md
+# Header Title {#custom-anchor}
+```
+
+This creates a header with a custom anchor that can be linked to using the `#custom-anchor` fragment in URLs.
+
+> **Note:** Using Hugo's header anchor syntax ensures consistency, compatibility with Hugo's internal linking, and better maintainability. Avoid using raw HTML for anchors.
+
 ### How to format internal links
 
 Internal links should use the [ref](https://gohugo.io/methods/shortcode/ref/#article) shortcode with absolute paths that start with a forward slash (for clarity).


### PR DESCRIPTION
Attempt to resolve issue 51

The user's intent is to ensure that all documentation uses Hugo's markdown syntax for custom anchors (i.e., `# Header {#custom-anchor}`) instead of raw HTML `<a name="...">` tags. The issue content specifically calls for a comprehensive review and update to replace any HTML anchor tags with the Hugo approach for consistency and best practices.

Reviewing the provided potential documents, most are templates, archetypes, or guides for documentation structure, and do not themselves contain actual anchor tags or examples of anchor usage. However, some of these documents (especially those that serve as templates or style guides) should explicitly instruct contributors to use the Hugo anchor syntax and discourage the use of raw HTML anchors. This will prevent future misuse and ensure consistency.

The most relevant document for this update is `CONTRIBUTING_DOCS.md`, which is the main guide for writers and already contains sections on markdown formatting and Hugo shortcodes. This is the logical place to add a section or note about using Hugo's anchor syntax and to explicitly discourage the use of `<a name="...">` tags.

Other archetype and template files (such as `archetypes/default.md`, `archetypes/concept.md`, `archetypes/tutorial.md`, and their equivalents in `.cloudcannon/schemas/`) do not currently demonstrate or mention anchor creation, so they do not need to be updated unless they contain explicit examples of anchor usage (which, in the provided content, they do not).

No other document in the provided list appears to contain instructions or examples related to anchor creation, nor do they contain raw HTML anchor tags.

Therefore, the change plan is to update `CONTRIBUTING_DOCS.md` to:
- Add a section or note under "How to format documentation" or "Basic Markdown formatting" that instructs writers to use Hugo's markdown anchor syntax for custom anchors.
- Explicitly state that raw HTML `<a name="...">` tags should not be used.
- Optionally, provide a brief example of the correct syntax.

No other documents require updates based on the provided content.