### PR TITLE
Documentation Update for Issue #594

### DIFF
--- a/content/nim/nginx-instances/manage-certificates.md
+++ b/content/nim/nginx-instances/manage-certificates.md
@@ -11,6 +11,10 @@ type:
 
 ## About certificates {#about-certificates}
 
+{{< call-out "note" "Best Practice: Enable Certificate Revocation Checking" >}}
+For maximum security, ensure that certificate revocation checking (using OCSP or Certificate Revocation Lists) is enabled on your NGINX instances when using managed certificates. This helps prevent the use of revoked certificates. For details on how to configure revocation checking, see the [Secure Traffic guide](https://docs.nginx.com/nginx-instance-manager/system-configuration/secure-traffic/).
+{{< /call-out >}}
+
 You can add certificates to **F5 NGINX Instance Manager** using the web interface or the REST API. Certificates in NGINX Instance Manager are stored in PEM format in an internal secret store. They can be published to NGINX instances, which use certificates to encrypt and decrypt requests and responses.
 
 NGINX Instance Manager can import the following types of certificates:

--- a/content/nim/system-configuration/secure-traffic.md
+++ b/content/nim/system-configuration/secure-traffic.md
@@ -465,6 +465,36 @@ To generate the necessary certificates, follow these steps. You can modify these
 
 ---
 
+## Certificate Revocation Checking (CRL/OCSP)
+
+{{< call-out "note" "Best practice: Enable certificate revocation checking" >}}
+To maximize the security of SSL/TLS connections between NGINX Instance Manager and NGINX instances, we recommend enabling certificate revocation checking. This ensures that certificates which have been revoked (for example, due to compromise or mis-issuance) are not accepted, reducing the risk of unauthorized access.
+
+Certificate revocation can be checked using:
+- **OCSP (Online Certificate Status Protocol):** Allows real-time validation of certificate status with the issuing Certificate Authority.
+- **CRL (Certificate Revocation List):** Uses a periodically updated list of revoked certificates published by the CA.
+
+**Example: Enabling OCSP validation in NGINX**
+
+Add the following directives to your SSL server block to enable OCSP checking:
+
+```nginx
+ssl_stapling on;
+ssl_stapling_verify on;
+ssl_trusted_certificate /etc/nms/certs/ca.pem;
+resolver 8.8.8.8 1.1.1.1 valid=300s;
+resolver_timeout 5s;
+```
+
+- `ssl_stapling on;` enables OCSP stapling.
+- `ssl_stapling_verify on;` ensures the OCSP response is verified.
+- `ssl_trusted_certificate` should point to your CA certificate chain.
+- `resolver` and `resolver_timeout` are required for OCSP to function.
+
+For more advanced revocation checking (including CRL), see the [NGINX SSL Termination guide](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/#enabling-ocsp-stapling).
+
+{{< /call-out >}}
+
 ## Configure SSL verification for usage reporting with self-signed certificates {#configure-ssl-verify}
 
 {{<call-out "note" "Version requirements" "">}}


### PR DESCRIPTION
Attempt to resolve issue 594

The user's intent is to ensure that the documentation for securing traffic between NGINX Instance Manager and NGINX instances explicitly mentions and recommends certificate revocation checking (using CRLs or OCSP) as a best practice. The goal is to prevent users from unknowingly accepting revoked certificates and to improve the overall security guidance.

Reviewing the potential documents:

1. **content/nim/system-configuration/secure-traffic.md**: This is the main guide for securing traffic between NGINX Instance Manager and NGINX instances. It covers SSL/mTLS setup, certificate management, and verification, but does not currently mention certificate revocation checking (CRL or OCSP) as a best practice or provide example configuration for it. This is the primary document that needs updating.

2. **content/nginx/admin-guide/security-controls/terminating-ssl-http.md**: This document already contains a section on OCSP validation of client certificates, including example configuration. However, it does not explicitly connect this to the NGINX Instance Manager use case or recommend it as a best practice in that context. A cross-reference or a brief note could be added, but the main update should be in the NIM-specific guide.

3. **content/nim/nginx-instances/manage-certificates.md**: This document is about managing certificates in NGINX Instance Manager, but it does not discuss the runtime validation of certificates (CRL/OCSP) for secure traffic. A brief mention or cross-reference could be helpful, but the main technical guidance belongs in the secure-traffic guide.

Other documents are not directly relevant to the intent.

Therefore, the main change should be to **content/nim/system-configuration/secure-traffic.md**, with a possible cross-reference or note in **content/nim/nginx-instances/manage-certificates.md**. The general NGINX SSL termination guide already covers OCSP, but a cross-link from the NIM guide would help.